### PR TITLE
Ajouter le support du lecteur Identiv CLOUD 4710 F

### DIFF
--- a/src/main/java/org/esupportail/esupnfctagkeyboard/service/pcsc/PcscUsbService.java
+++ b/src/main/java/org/esupportail/esupnfctagkeyboard/service/pcsc/PcscUsbService.java
@@ -62,7 +62,7 @@ public class PcscUsbService {
 	public String connection() throws CardException{
 		if(terminals.list().size()>0) {
 			for (CardTerminal terminal : terminals.list()) {
-				if(!terminal.getName().contains("6121") && terminal.isCardPresent()){
+				if(!terminal.getName().contains("6121") && !terminal.getName().contains("SAM Reader") && terminal.isCardPresent()){
 					cardTerminal = terminal;
 					try{
 						card = cardTerminal.connect("*");
@@ -91,7 +91,7 @@ public class PcscUsbService {
 			}
 			for (CardTerminal terminal : terminals.list()) {
 			try {
-				if(!terminal.getName().contains("6121") && terminal.isCardPresent()) return true; 
+				if(!terminal.getName().contains("6121") && !terminal.getName().contains("SAM Reader") && terminal.isCardPresent()) return true; 
 			} catch (CardException e) {
 				log.info("Pas de carte");
 			}


### PR DESCRIPTION
Ce lecteur contient 2 périphériques :
- uTrust 4710 F CL Reader
- uTrust 4710 F SAM Reader

Il faut ignorer le SAM Reader, car ce périphérique ne permet pas de lire les cartes NFC.